### PR TITLE
Keep private_comment private

### DIFF
--- a/etc/sample.fediblockhole.conf.toml
+++ b/etc/sample.fediblockhole.conf.toml
@@ -39,3 +39,9 @@ blocklist_instance_destinations = [
 # The 'min' mergeplan will use the lightest severity block found for a domain.
 # mergeplan = 'max'
 
+## Include private_comment field when exporting or importing a blocklist.
+## By default this isn't exported or imported to keep private comments private, but
+## if you're using this tool to back up or maintain your own bulk blocklists you might
+## want to include the private comments as well. Use with care.
+## 
+#include_private_comments = false


### PR DESCRIPTION
Exclude `private_comment` field from exports and imports by default.

Add `--include-private-comments` commandline and config option to re-enable `private_comment` inclusion if you want to.

Addresses issue: #1 