### PR TITLE
Block instances 'gently' so people on them have time to escape.

### DIFF
--- a/etc/sample.fediblockhole.conf.toml
+++ b/etc/sample.fediblockhole.conf.toml
@@ -17,11 +17,11 @@ blocklist_url_sources = [
 
 # List of instances to write blocklist to
 blocklist_instance_destinations = [
-  # { domain = 'eigenmagic.net', token = '<read_write_token>' },
+  # { domain = 'eigenmagic.net', token = '<read_write_token>', max_followed_severity = 'silence'},
 ]
 
 ## Store a local copy of the remote blocklists after we fetch them
-#keep_intermediate = true
+#save_intermediate = true
 
 ## Directory to store the local blocklist copies
 # savedir = '/tmp'


### PR DESCRIPTION
Implements the idea from #5

Set a maximum severity for blocks if an instance has people on it that follow a domain that's getting blocked.

The default is to make the maximum domain_block severity 'silence' if there are followers of accounts on the to-be-blocked domain on your instance. That buys them time to move to another instance and migrate their followers from your instance before you escalate the block to a full Suspend.

Settable per-instance you push to so you can maintain multiple instances from a central point, if you want.