### PR TITLE
Don't require default config when testing

### DIFF
--- a/tests/helpers/util.py
+++ b/tests/helpers/util.py
@@ -7,5 +7,6 @@ def shim_argparse(testargv: list=[], tomldata: str=None):
     """
     ap = setup_argparse()
     args = ap.parse_args(testargv)
-    args = augment_args(args, tomldata)
+    if tomldata is not None:
+        args = augment_args(args, tomldata)
     return args


### PR DESCRIPTION
The test util `shim_argparse` will no longer try to augment the args if no toml data is provided.

Fixes a bug with testing on a brand new install where no default config file has been set up on the host.