### PR TITLE
Use __future__.annotations so type hints work with Python < 2.9

### DIFF
--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -1,6 +1,6 @@
 """A tool for managing federated Mastodon blocklists
 """
-
+from __future__ import annotations
 import argparse
 import toml
 import csv

--- a/src/fediblockhole/blocklists.py
+++ b/src/fediblockhole/blocklists.py
@@ -1,5 +1,6 @@
 """Parse various blocklist data formats
 """
+from __future__ import annotations
 import csv
 import json
 from typing import Iterable

--- a/src/fediblockhole/const.py
+++ b/src/fediblockhole/const.py
@@ -1,5 +1,6 @@
 """ Constant objects used by FediBlockHole
 """
+from __future__ import annotations
 import enum
 from typing import NamedTuple, Optional, TypedDict
 from dataclasses import dataclass


### PR DESCRIPTION
Python <2.9 doesn't support type hinting with generics, which we started using.

But Ubuntu 20.04LTS has Python 3.8.10 (at time of writing) so fediblockhole doesn't work on it, which sucks for people who are on that distro. It's a long-term support distro and it's not unreasonable for people using it to want Fediblockhole to work there.

Happily, we don't have to remove the type hinting, because we can tell Python 3.8 about type annotations from the future!

Fixes #51 