### PR TITLE
Domain audit file

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,11 @@ The filename is based on the URL or domain used so you can tell where each list 
 
 Sets where to save intermediate blocklist files. Defaults to `/tmp`.
 
+### blocklist_auditfile
+
+If provided, will save an audit file of counts and percentages by domain. Useful for debugging 
+thresholds. Defaults to None.
+
 ### no_push_instance
 
 Defaults to False.

--- a/etc/sample.fediblockhole.conf.toml
+++ b/etc/sample.fediblockhole.conf.toml
@@ -42,6 +42,9 @@ blocklist_instance_destinations = [
 ## File to save the fully merged blocklist into
 # blocklist_savefile = '/tmp/merged_blocklist.csv'
 
+## File to save the audit log of counts across sources
+# blocklist_auditfile = '/tmp/domain_counts_list.csv'
+
 ## Don't push blocklist to instances, even if they're defined above
 # no_push_instance = false
 

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -184,7 +184,7 @@ def fetch_from_instances(sources: dict,
 def merge_blocklists(blocklists: list[Blocklist], mergeplan: str='max',
     threshold: int=0,
     threshold_type: str='count',
-    save_block_audit_file: str='') -> Blocklist:
+    save_block_audit_file: str=None) -> Blocklist:
     """Merge fetched remote blocklists into a bulk update
     @param blocklists: A dict of lists of DomainBlocks, keyed by source.
         Each value is a list of DomainBlocks
@@ -242,7 +242,7 @@ def merge_blocklists(blocklists: list[Blocklist], mergeplan: str='max',
                 block = apply_mergeplan(block, newblock, mergeplan)
             merged.blocks[block.domain] = block
 
-        if len(save_block_audit_file) > 0:
+        if save_block_audit_file:
             blockdata:BlockAudit = {
                 'domain': domain,
                 'count': domain_matches_count, 
@@ -250,7 +250,7 @@ def merge_blocklists(blocklists: list[Blocklist], mergeplan: str='max',
             }
             audit.blocks[domain] = blockdata
 
-    if len(save_block_audit_file) > 0:
+    if save_block_audit_file:
         log.info(f"Saving audit file to {save_block_audit_file}")
         save_domain_block_audit_to_file(audit, save_block_audit_file)
 
@@ -746,7 +746,7 @@ def augment_args(args, tomldata: str=None):
         args.savedir = conf.get('savedir', '/tmp')
 
     if not args.blocklist_auditfile:
-        args.blocklist_auditfile = conf.get('blocklist_auditfile', '')
+        args.blocklist_auditfile = conf.get('blocklist_auditfile', None)
 
     if not args.export_fields:
         args.export_fields = conf.get('export_fields', [])

--- a/src/fediblockhole/blocklists.py
+++ b/src/fediblockhole/blocklists.py
@@ -6,7 +6,7 @@ import json
 from typing import Iterable
 from dataclasses import dataclass, field
 
-from .const import DomainBlock, BlockSeverity
+from .const import DomainBlock, BlockSeverity, BlockAudit
 
 import logging
 log = logging.getLogger('fediblockhole')
@@ -25,6 +25,33 @@ class Blocklist:
 
     def __class_getitem__(cls, item):
         return dict[str, DomainBlock]
+
+    def __getitem__(self, item):
+        return self.blocks[item]
+
+    def __iter__(self):
+        return self.blocks.__iter__()
+
+    def items(self):
+        return self.blocks.items()
+
+    def values(self):
+        return self.blocks.values()
+
+@dataclass   
+class BlockAuditList:
+    """ A BlockAuditlist object
+
+    A BlockAuditlist is a list of BlockAudits from an origin
+    """
+    origin: str = None
+    blocks: dict[str, BlockAudit] = field(default_factory=dict)
+
+    def __len__(self):
+        return len(self.blocks)
+
+    def __class_getitem__(cls, item):
+        return dict[str, BlockAudit]
 
     def __getitem__(self, item):
         return self.blocks[item]

--- a/src/fediblockhole/const.py
+++ b/src/fediblockhole/const.py
@@ -84,6 +84,81 @@ class BlockSeverity(object):
     def __ge__(self, other):
         if self._level >= other._level:
             return True
+        
+class BlockAudit(object):
+
+    fields = [
+        'domain',
+        'count',
+        'percent',
+    ]
+
+    all_fields = [
+        'domain',
+        'count',
+        'percent',
+        'id'
+    ]
+
+    def __init__(self, domain:str,
+            count: int=0,
+            percent: int=0,
+            id: int=None):
+        """Initialize the BlockAudit
+        """        
+        self.domain = domain
+        self.count = count
+        self.percent = percent
+        self.id = id
+
+    def _asdict(self):
+        """Return a dict version of this object
+        """
+        dictval = {
+            'domain': self.domain,
+            'count': self.count,
+            'percent': self.percent,
+        }
+        if self.id:
+            dictval['id'] = self.id
+
+        return dictval
+
+    def __repr__(self):
+
+        return f"<BlockAudit {self._asdict()}>"
+
+    def copy(self):
+        """Make a copy of this object and return it
+        """
+        retval = BlockAudit(**self._asdict())
+        return retval
+
+    def update(self, dict):
+        """Update my kwargs
+        """
+        for key in dict:
+            setattr(self, key, dict[key])
+
+    def __iter__(self):
+        """Be iterable"""
+        keys = self.fields
+
+        if getattr(self, 'id', False):
+            keys.append('id')
+
+        for k in keys:
+            yield k
+
+    def __getitem__(self, k, default=None):
+        "Behave like a dict for getting values"
+        if k not in self.all_fields:
+            raise KeyError(f"Invalid key '{k}'")
+
+        return getattr(self, k, default)
+
+    def get(self, k, default=None):
+        return self.__getitem__(k, default)
 
 # class _DomainBlock(NamedTuple):
 #     domain: str # FIXME: Use an actual Domain object from somewhere?


### PR DESCRIPTION
Allows for the creation of a Blocklist Audit File.

This audit file can be used to return metadata about each domain match, such as the number of matches by count or percentage.

(This was primarily done for my own needs, but it should be easy enough to ignore for users who do not want to use this feature, as by default it's not enabled.)