### PR TITLE
Override private comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,14 @@ Skip the fetching of blocklists from any URLs that are configured.
 
 Skip the fetching of blocklists from any remote instances that are configured.
 
+### override_private_comment
+
+Defaults to None.
+
+Stamp all *new* blocks pushed to a remote server with this comment or code. 
+Helps to identify blocks you've created on a server via this process versus ones that
+already existed.
+
 ### mergeplan
 
 If two (or more) blocklists define blocks for the same domain, but they're

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Skip the fetching of blocklists from any remote instances that are configured.
 Defaults to None.
 
 Stamp all *new* blocks pushed to a remote server with this comment or code. 
-Helps to identify blocks you've created on a server via this process versus ones that
+Helps to identify blocks you've created on a server via Fediblockhole versus ones that
 already existed.
 
 ### mergeplan

--- a/etc/sample.fediblockhole.conf.toml
+++ b/etc/sample.fediblockhole.conf.toml
@@ -77,6 +77,9 @@ blocklist_instance_destinations = [
 # merge_threshold_type = 'count'
 # merge_threshold = 0
 
+## set an override private comment
+# override_private_comment = 'Updated by Fediblockhole'
+
 ## Set which fields we import
 ## 'domain' and 'severity' are always imported, these are additional
 ## 

--- a/etc/sample.fediblockhole.conf.toml
+++ b/etc/sample.fediblockhole.conf.toml
@@ -77,8 +77,9 @@ blocklist_instance_destinations = [
 # merge_threshold_type = 'count'
 # merge_threshold = 0
 
-## set an override private comment
-# override_private_comment = 'Updated by Fediblockhole'
+## set an override private comment to be added when pushing a NEW block to an instance
+# this does not require importing private comments
+# override_private_comment = 'Added by Fediblock Sync'
 
 ## Set which fields we import
 ## 'domain' and 'severity' are always imported, these are additional

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -581,10 +581,6 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
     # # Convert serverblocks to a dictionary keyed by domain name
     # knownblocks = {row.domain: row for row in serverblocks}
 
-    log.debug(f"Checking server blocks: {serverblocks}")
-    for block in serverblocks:
-        log.debug(f"Checking block: {block}")
-
     for newblock in blocklist.values():
 
         log.debug(f"Processing block: {newblock}")

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -402,6 +402,9 @@ def fetch_instance_blocklist(host: str, token: str=None, admin: bool=False,
     link = True
     while link:
         response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
+        if response.status_code == 401:
+            log.error(f"Cannot fetch remote blocklist. Access token has been revoked for {host}, skipping....")
+            break
         if response.status_code != 200:
             log.error(f"Cannot fetch remote blocklist: {response.content}")
             raise ValueError("Unable to fetch domain block list: %s", response)

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -485,7 +485,8 @@ def fetch_instance_follows(token: str, host: str, domain: str, scheme: str='http
         if response.status_code == 403:
             log.error(f"Cannot fetch follow information for {domain} from {host}: {response.content}")
 
-        raise ValueError(f"Something went wrong: {response.status_code}: {response.content}")
+        if response.status_code != 401:
+            raise ValueError(f"Something went wrong: {response.status_code}: {response.content}")
 
     # Get the total returned
     follows = int(response.json()[0]['total'])

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -628,7 +628,7 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
             # stamp this record with a private comment, since we're the ones adding it
             if override_private_comment:
                 newblock.private_comment = override_private_comment
-                
+
             # This is a new block for the target instance, so we
             # need to add a block rather than update an existing one
             log.info(f"Adding new block: {newblock}...")
@@ -642,6 +642,9 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
                 time.sleep(API_CALL_DELAY)
             else:
                 log.info("Dry run selected. Not adding block.")
+
+    for block in serverblocks:
+        log.debug(f"Checking block: {block}")
 
 def load_config(configfile: str):
     """Augment commandline arguments with config file parameters

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -576,8 +576,6 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
     # Force use of the admin API, and add 'id' to the list of fields
     if 'id' not in import_fields:
         import_fields.append('id')
-    if override_private_comment:
-        import_fields.append('private_comment')
     serverblocks = fetch_instance_blocklist(host, token, True, import_fields, scheme)
 
     # # Convert serverblocks to a dictionary keyed by domain name

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -643,6 +643,7 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
             else:
                 log.info("Dry run selected. Not adding block.")
 
+    log.debug(f"Checking server blocks: {serverblocks}")
     for block in serverblocks:
         log.debug(f"Checking block: {block}")
 

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -90,7 +90,7 @@ def sync_blocklists(conf: argparse.Namespace):
             token = dest['token']
             scheme = dest.get('scheme', 'https')
             max_followed_severity = BlockSeverity(dest.get('max_followed_severity', 'silence'))
-            push_blocklist(token, target, merged, conf.dryrun, import_fields, max_followed_severity, scheme)
+            push_blocklist(token, target, merged, conf.dryrun, import_fields, max_followed_severity, scheme, conf.override_private_comment)
 
 def apply_allowlists(merged: Blocklist, conf: argparse.Namespace, allowlists: dict):
     """Apply allowlists
@@ -560,6 +560,7 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
                     import_fields: list=['domain', 'severity'],
                     max_followed_severity:BlockSeverity=BlockSeverity('silence'),
                     scheme: str='https',
+                    override_private_comment: str=None
                     ):
     """Push a blocklist to a remote instance.
     
@@ -575,12 +576,20 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
     # Force use of the admin API, and add 'id' to the list of fields
     if 'id' not in import_fields:
         import_fields.append('id')
+
+    # if we're overriding the private comment, we need to include it in the import
+    if override_private_comment:
+        import_fields.append('private_comment')
     serverblocks = fetch_instance_blocklist(host, token, True, import_fields, scheme)
 
     # # Convert serverblocks to a dictionary keyed by domain name
     # knownblocks = {row.domain: row for row in serverblocks}
 
     for newblock in blocklist.values():
+
+        # stamp this record with a private comment
+        if override_private_comment:
+            newblock.private_comment = override_private_comment
 
         log.debug(f"Processing block: {newblock}")
         if newblock.domain in serverblocks:
@@ -741,6 +750,9 @@ def augment_args(args, tomldata: str=None):
 
     if not args.save_intermediate:
         args.save_intermediate = conf.get('save_intermediate', False)
+
+    if not args.override_private_comment:
+        args.override_private_comment = conf.get('override_private_comment', None)
     
     if not args.savedir:
         args.savedir = conf.get('savedir', '/tmp')
@@ -787,6 +799,7 @@ def setup_argparse():
     ap.add_argument('-b', '--block-audit-file', dest="blocklist_auditfile", help="Save blocklist auditfile to this location.")
     ap.add_argument('--merge-threshold', type=int, help="Merge threshold value")
     ap.add_argument('--merge-threshold-type', choices=['count', 'pct'], help="Type of merge threshold to use.")
+    ap.add_argument('--override-private-comment', dest='override_private_comment', help="Enforces a private comment for all blocks.")
 
     ap.add_argument('-I', '--import-field', dest='import_fields', action='append', help="Extra blocklist fields to import.")
     ap.add_argument('-E', '--export-field', dest='export_fields', action='append', help="Extra blocklist fields to export.")

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -576,10 +576,6 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
     # Force use of the admin API, and add 'id' to the list of fields
     if 'id' not in import_fields:
         import_fields.append('id')
-
-    # if we're overriding the private comment, we need to include it in the import
-    if override_private_comment:
-        import_fields.append('private_comment')
     serverblocks = fetch_instance_blocklist(host, token, True, import_fields, scheme)
 
     # # Convert serverblocks to a dictionary keyed by domain name

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -625,14 +625,14 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
                 pass
 
         else:
+            # stamp this record with a private comment, since we're the ones adding it
+            if override_private_comment:
+                newblock.private_comment = override_private_comment
+                
             # This is a new block for the target instance, so we
             # need to add a block rather than update an existing one
             log.info(f"Adding new block: {newblock}...")
             log.debug(f"Block as dict: {newblock._asdict()}")
-
-             # stamp this record with a private comment, since we're the ones adding it
-            if override_private_comment:
-                newblock.private_comment = override_private_comment
 
             # Make sure the new block doesn't clobber a domain with followers
             newblock.severity = check_followed_severity(host, token, newblock.domain, newblock.severity, max_followed_severity, scheme)

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -576,6 +576,8 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
     # Force use of the admin API, and add 'id' to the list of fields
     if 'id' not in import_fields:
         import_fields.append('id')
+    if override_private_comment:
+        import_fields.append('private_comment')
     serverblocks = fetch_instance_blocklist(host, token, True, import_fields, scheme)
 
     # # Convert serverblocks to a dictionary keyed by domain name

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -402,9 +402,6 @@ def fetch_instance_blocklist(host: str, token: str=None, admin: bool=False,
     link = True
     while link:
         response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
-        if response.status_code == 401:
-            log.error(f"Cannot fetch remote blocklist. Access token has been revoked for {host}, skipping....")
-            break
         if response.status_code != 200:
             log.error(f"Cannot fetch remote blocklist: {response.content}")
             raise ValueError("Unable to fetch domain block list: %s", response)
@@ -485,8 +482,7 @@ def fetch_instance_follows(token: str, host: str, domain: str, scheme: str='http
         if response.status_code == 403:
             log.error(f"Cannot fetch follow information for {domain} from {host}: {response.content}")
 
-        if response.status_code != 401:
-            raise ValueError(f"Something went wrong: {response.status_code}: {response.content}")
+        raise ValueError(f"Something went wrong: {response.status_code}: {response.content}")
 
     # Get the total returned
     follows = int(response.json()[0]['total'])
@@ -554,9 +550,6 @@ def add_block(token: str, host: str, blockdata: DomainBlock, scheme: str='https'
         # A stricter block already exists. Probably for the base domain.
         err = json.loads(response.content)
         log.warning(err['error'])
-
-    elif response.status_code == 401:
-        log.warning(f"Access token has been revoked for {host}, no blocks being updated.")
 
     elif response.status_code != 200:
             

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -587,10 +587,6 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
 
     for newblock in blocklist.values():
 
-        # stamp this record with a private comment
-        if override_private_comment:
-            newblock.private_comment = override_private_comment
-
         log.debug(f"Processing block: {newblock}")
         if newblock.domain in serverblocks:
             log.debug(f"Block already exists for {newblock.domain}, checking for differences...")
@@ -637,6 +633,10 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
             # need to add a block rather than update an existing one
             log.info(f"Adding new block: {newblock}...")
             log.debug(f"Block as dict: {newblock._asdict()}")
+
+             # stamp this record with a private comment, since we're the ones adding it
+            if override_private_comment:
+                newblock.private_comment = override_private_comment
 
             # Make sure the new block doesn't clobber a domain with followers
             newblock.severity = check_followed_severity(host, token, newblock.domain, newblock.severity, max_followed_severity, scheme)

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -581,6 +581,10 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
     # # Convert serverblocks to a dictionary keyed by domain name
     # knownblocks = {row.domain: row for row in serverblocks}
 
+    log.debug(f"Checking server blocks: {serverblocks}")
+    for block in serverblocks:
+        log.debug(f"Checking block: {block}")
+
     for newblock in blocklist.values():
 
         log.debug(f"Processing block: {newblock}")
@@ -642,10 +646,6 @@ def push_blocklist(token: str, host: str, blocklist: list[DomainBlock],
                 time.sleep(API_CALL_DELAY)
             else:
                 log.info("Dry run selected. Not adding block.")
-
-    log.debug(f"Checking server blocks: {serverblocks}")
-    for block in serverblocks:
-        log.debug(f"Checking block: {block}")
 
 def load_config(configfile: str):
     """Augment commandline arguments with config file parameters

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -795,7 +795,7 @@ def setup_argparse():
     ap.add_argument('-b', '--block-audit-file', dest="blocklist_auditfile", help="Save blocklist auditfile to this location.")
     ap.add_argument('--merge-threshold', type=int, help="Merge threshold value")
     ap.add_argument('--merge-threshold-type', choices=['count', 'pct'], help="Type of merge threshold to use.")
-    ap.add_argument('--override-private-comment', dest='override_private_comment', help="Enforces a private comment for all blocks.")
+    ap.add_argument('--override-private-comment', dest='override_private_comment', help="Override private_comment with this string for new blocks when pushing blocklists.")
 
     ap.add_argument('-I', '--import-field', dest='import_fields', action='append', help="Extra blocklist fields to import.")
     ap.add_argument('-E', '--export-field', dest='export_fields', action='append', help="Extra blocklist fields to export.")

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -554,6 +554,9 @@ def add_block(token: str, host: str, blockdata: DomainBlock, scheme: str='https'
         err = json.loads(response.content)
         log.warning(err['error'])
 
+    elif response.status_code == 401:
+        log.warning(f"Access token has been revoked for {host}, no blocks being updated.")
+
     elif response.status_code != 200:
             
         raise ValueError(f"Something went wrong: {response.status_code}: {response.content}")


### PR DESCRIPTION
When pushing to a remote server and pushing a *new* block, it's often helpful to know where that block came from.

With `override_private_comment` param, you can essentially 'stamp' whatever you want into the private comment when *adding* (not editing) a block.

This works similarly to how importing a Mastodon.csv file works now: It will put "Imported from xyz.blocklist on [date]" in the Private Comment.

This way, when a user receives a pushed domain and wonders where it came from, they can always check the private comment and see the source.