### PR TITLE
Add support for acquiring instance tokens from the environment instead of explicitly in configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,10 +288,23 @@ Configure the list of instances you want to push your blocklist to in the
 { domain = '<domain_name>', token = '<BearerToken>', import_fields = ['public_comment'], max_severity = 'suspend', max_followed_severity = 'suspend' }
 ```
 
-The fields `domain` and `token` are required. The `token` field can either be 
-directly included in the file (which is not recommended) or it can be in your 
-enviromnent, and referenced using the syntax `$ENV:<ENV_VAR>`, which will insert 
-the contents of `ENV_VAR` at that point.
+The `domain` field is required. 
+
+One of the three token sources are required:
+
+* directly specifying a `token` field in the item:
+
+    ```toml
+    { domain = '<domain_name>', token = '<BearerToken>', import_fields = ['public_comment'], max_severity = 'suspend', max_followed_severity = 'suspend' }
+    ```
+
+* specifying a `token_env_var` in the item, which contains the value of the token:
+
+    ```toml
+    { domain = '<domain_name>', token_env_var = 'BEARER_TOKEN_ENV_VAR', import_fields = ['public_comment'], max_severity = 'suspend', max_followed_severity = 'suspend' }
+    ```
+
+* Setting a standardized domain name environment variable based on the value of the `domain` key. The environment variable must be the domain, converted to uppercase, with all `.` characters replaced by `_`, then suffixed by `_TOKEN`. If the domain is `example.com` then fediblockhole will look for `EXAMPLE_COM_TOKEN` in the environment. 
 
 The fields `max_followed_severity` and `import_fields` are optional.
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,10 @@ Configure the list of instances you want to push your blocklist to in the
 { domain = '<domain_name>', token = '<BearerToken>', import_fields = ['public_comment'], max_severity = 'suspend', max_followed_severity = 'suspend' }
 ```
 
-The fields `domain` and `token` are required. 
+The fields `domain` and `token` are required. The `token` field can either be 
+directly included in the file (which is not recommended) or it can be in your 
+enviromnent, and referenced using the syntax `$ENV:<ENV_VAR>`, which will insert 
+the contents of `ENV_VAR` at that point.
 
 The fields `max_followed_severity` and `import_fields` are optional.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.4.5"
 description = "Federated blocklist management for Mastodon"
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 keywords = ["mastodon", "fediblock"]
 authors = [ 
     {name = "Justin Warren"}, {email = "justin@eigenmagic.com"}
@@ -19,8 +19,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.6",
 ]
 dependencies = [
     "requests",
@@ -42,4 +40,9 @@ build-backend = "hatchling.build"
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=importlib",
+]
+
+[tool.uv]
+dev-dependencies = [
+    "pytest>=7.0.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,5 +44,5 @@ addopts = [
 
 [tool.uv]
 dev-dependencies = [
-    "pytest>=7.0.1",
+    "pytest~=8.3",
 ]

--- a/src/fediblockhole/__init__.py
+++ b/src/fediblockhole/__init__.py
@@ -736,7 +736,8 @@ def resolve_replacements(endpoints: list[dict]) -> list[dict]:
             ...
 
         elif 'token_env_var' in item:
-            value = os.getenv(item['token_env_var'])
+            token_env_var = item['token_env_var']
+            value = os.environ.get(token_env_var)
             if value is None:
                 raise ValueError(f"Environment variable '{item["token_env_var"]}' not set.")
 

--- a/tests/test_configfile.py
+++ b/tests/test_configfile.py
@@ -1,5 +1,8 @@
 """Test the config file is loading parameters correctly
 """
+from textwrap import dedent
+from unittest.mock import patch
+
 from util import shim_argparse
 from fediblockhole import setup_argparse, augment_args
 
@@ -79,3 +82,30 @@ merge_threshold = 35
     assert args.mergeplan == 'max'
     assert args.merge_threshold_type == 'pct'
     assert args.merge_threshold == 35
+
+def test_destination_token_from_environment():
+    tomldata = dedent("""\
+    blocklist_instance_destinations = [
+      { domain='example.com', token='raw-token'},
+      { domain='example2.com', token='$ENV:TOKEN_ENV_VAR' },
+    ]
+    """)
+
+    with patch.dict('os.environ', {'TOKEN_ENV_VAR': 'env-token'}):
+        args = shim_argparse([], tomldata)
+    assert args.blocklist_instance_destinations[0]['token'] == 'raw-token'
+    assert args.blocklist_instance_destinations[1]['token'] == 'env-token'
+
+
+def test_instance_sources_token_from_environment():
+    tomldata = dedent("""\
+    blocklist_instance_sources = [
+      { domain='example.com', token='raw-token'},
+      { domain='example2.com', token='$ENV:TOKEN_ENV_VAR' },
+    ]
+    """)
+
+    with patch.dict('os.environ', {'TOKEN_ENV_VAR': 'env-token'}):
+        args = shim_argparse([], tomldata)
+    assert args.blocklist_instance_sources[0]['token'] == 'raw-token'
+    assert args.blocklist_instance_sources[1]['token'] == 'env-token'

--- a/tests/test_configfile.py
+++ b/tests/test_configfile.py
@@ -87,25 +87,41 @@ def test_destination_token_from_environment():
     tomldata = dedent("""\
     blocklist_instance_destinations = [
       { domain='example.com', token='raw-token'},
-      { domain='example2.com', token='$ENV:TOKEN_ENV_VAR' },
+      { domain='example2.com', token_env_var='TOKEN_ENV_VAR' },
+      { domain='env-token.com' },
+      { domain='www.env-token.com' },
     ]
     """)
 
-    with patch.dict('os.environ', {'TOKEN_ENV_VAR': 'env-token'}):
+    with patch.dict('os.environ', {
+            'TOKEN_ENV_VAR': 'env-token',
+            'ENV-TOKEN_COM_TOKEN': 'env-token',
+            'WWW_ENV-TOKEN_COM_TOKEN': 'www-env-token',
+    }):
         args = shim_argparse([], tomldata)
     assert args.blocklist_instance_destinations[0]['token'] == 'raw-token'
     assert args.blocklist_instance_destinations[1]['token'] == 'env-token'
+    assert args.blocklist_instance_destinations[2]['token'] == 'env-token'
+    assert args.blocklist_instance_destinations[3]['token'] == 'www-env-token'
 
 
 def test_instance_sources_token_from_environment():
     tomldata = dedent("""\
     blocklist_instance_sources = [
       { domain='example.com', token='raw-token'},
-      { domain='example2.com', token='$ENV:TOKEN_ENV_VAR' },
+      { domain='example2.com', token_env_var='TOKEN_ENV_VAR' },
+      { domain='env-token.com' },
+      { domain='www.env-token.com' },
     ]
     """)
 
-    with patch.dict('os.environ', {'TOKEN_ENV_VAR': 'env-token'}):
+    with patch.dict('os.environ', {
+            'TOKEN_ENV_VAR': 'env-token',
+            'ENV-TOKEN_COM_TOKEN': 'env-token',
+            'WWW_ENV-TOKEN_COM_TOKEN': 'www-env-token',
+    }):
         args = shim_argparse([], tomldata)
     assert args.blocklist_instance_sources[0]['token'] == 'raw-token'
     assert args.blocklist_instance_sources[1]['token'] == 'env-token'
+    assert args.blocklist_instance_sources[2]['token'] == 'env-token'
+    assert args.blocklist_instance_sources[3]['token'] == 'www-env-token'


### PR DESCRIPTION
Fixes #61

The new syntax allows tokens to be left out of configuration and
provided by arbitrary environment variables. This means it'll be safe to
commit configurations for fediblockhole to source control

### A note on versions

The code in the project requires Python 3.8, so I changed the dependencies to reflect it (and ran tests with 3.8 and 3.12). I put a uv dev-dependencies block in because I use uv locally; if that's a dealbreaker, fine to remove it, but it certainly was nice to have.

### A note on code formatting

I intentionally did not reformat this code, but FYI when I run `black` or `ruff` on it -- which my editor does automatically, and I had to turn off :) -- it rewrites a _lot_; dunno if you're motivated to use those, if you are, happy to submit a PR for that too.