### PR TITLE
Adds ability to fetch BearerTokens from environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,19 +282,52 @@ permit access to the admin domain_blocks scope, as detailed above.
 The tool supports pushing a unified blocklist to multiple instances.
 
 Configure the list of instances you want to push your blocklist to in the
-`blocklist_instance_detinations` list. Each entry is of the form:
+`blocklist_instance_destinations` list. Each entry is of the form:
 
 ```
-{ domain = '<domain_name>', token = '<BearerToken>', import_fields = ['public_comment'], max_severity = 'suspend', max_followed_severity = 'suspend' }
+{ domain = '<domain_name>', import_fields = ['public_comment'], max_severity = 'suspend', max_followed_severity = 'suspend' }
 ```
 
-The fields `domain` and `token` are required. 
+The field `domain` is required. It is the fully-qualified domain name of the
+instance you want to push to. 
 
-The fields `max_followed_severity` and `import_fields` are optional.
+A BearerToken is also required, for authenticating with the instance. It can be provided in two ways:
 
-The `domain` is the hostname of the instance you want to push to. The `token` is
+1. A token can be provided directly in the entry as a `token` field, like this:
+    ```
+    { domain = '<domain_name>', token = '<BearerToken>', import_fields = ['public_comment'], max_severity = 'suspend', max_followed_severity = 'suspend' }
+    ```
+    This was the only mechanism available up to version 0.4.5 of Fediblockhole.
+
+1. A token can be provided from the environment.
+
+    If a token is not directly provided with the `token` field, Fediblockhole will
+    look for an environment variable that contains the token.
+
+    By default, the name of the environment variable will be the domain name
+    converted to upper case and with dot/period characters converted to
+    underscores, and the suffix `_TOKEN`. For example, the token variable for the
+    domain `eigenmagic.net` would be `EIGENMAGIC_NET_TOKEN`.
+
+    You can also specify the environment variable to look for, using the
+    `token_env_var` field, like this:
+    ```
+    { domain = '<domain_name>', token_env_var = 'MY_CUSTOM_DOMAIN_TOKEN', import_fields = ['public_comment'], max_severity = 'suspend', max_followed_severity = 'suspend' }
+    ```
+
+    Fediblockhole will then look for a token in the `MY_CUSTOM_DOMAIN_TOKEN` environment variable.
+
+    If a specific `token_env_var` is provided, the default variable name will
+    not be used. If both the `token` and `token_env_var` fields are provided,
+    the token provided in the `token` field will be used, and a warning will be
+    issued to notify you that you might have misconfigured things.
+
+
+The BearerToken is
 an application token with both `admin:read:domain_blocks` and
 `admin:write:domain_blocks` authorization.
+
+The fields `max_followed_severity` and `import_fields` are optional.
 
 The optional `import_fields` setting allows you to restrict which fields are
 imported from each instance. If you want to import the `reject_reports` settings

--- a/tests/helpers/util.py
+++ b/tests/helpers/util.py
@@ -2,7 +2,8 @@
 """
 from fediblockhole import setup_argparse, augment_args
 
-def shim_argparse(testargv: list=[], tomldata: str=None):
+
+def shim_argparse(testargv: list = [], tomldata: str = None):
     """Helper function to parse test args
     """
     ap = setup_argparse()

--- a/tests/test_configfile.py
+++ b/tests/test_configfile.py
@@ -1,6 +1,8 @@
 """Test the config file is loading parameters correctly
 """
 
+from textwrap import dedent
+
 from util import shim_argparse
 
 from fediblockhole import augment_args, setup_argparse
@@ -90,3 +92,51 @@ merge_threshold = 35
     assert args.mergeplan == "max"
     assert args.merge_threshold_type == "pct"
     assert args.merge_threshold == 35
+
+
+def test_destination_token_from_environment(monkeypatch):
+    tomldata = dedent(
+        """\
+    blocklist_instance_destinations = [
+      { domain='example.com', token='raw-token'},
+      { domain='example2.com', token_env_var='TOKEN_ENV_VAR' },
+      { domain='env-token.com' },
+      { domain='www.env-token.com' },
+    ]
+    """
+    )
+
+    monkeypatch.setenv("TOKEN_ENV_VAR", "env-token")
+    monkeypatch.setenv("ENV-TOKEN_COM_TOKEN", "env-token")
+    monkeypatch.setenv("WWW_ENV-TOKEN_COM_TOKEN", "www-env-token")
+
+    args = shim_argparse([], tomldata)
+
+    assert args.blocklist_instance_destinations[0]["token"] == "raw-token"
+    assert args.blocklist_instance_destinations[1]["token"] == "env-token"
+    assert args.blocklist_instance_destinations[2]["token"] == "env-token"
+    assert args.blocklist_instance_destinations[3]["token"] == "www-env-token"
+
+
+def test_instance_sources_token_from_environment(monkeypatch):
+    tomldata = dedent(
+        """\
+    blocklist_instance_sources = [
+      { domain='example.com', token='raw-token'},
+      { domain='example2.com', token_env_var='TOKEN_ENV_VAR' },
+      { domain='env-token.com' },
+      { domain='www.env-token.com' },
+    ]
+    """
+    )
+
+    monkeypatch.setenv("TOKEN_ENV_VAR", "env-token")
+    monkeypatch.setenv("ENV-TOKEN_COM_TOKEN", "env-token")
+    monkeypatch.setenv("WWW_ENV-TOKEN_COM_TOKEN", "www-env-token")
+
+    args = shim_argparse([], tomldata)
+
+    assert args.blocklist_instance_sources[0]["token"] == "raw-token"
+    assert args.blocklist_instance_sources[1]["token"] == "env-token"
+    assert args.blocklist_instance_sources[2]["token"] == "env-token"
+    assert args.blocklist_instance_sources[3]["token"] == "www-env-token"


### PR DESCRIPTION
Uses the code from @offbyone in #62 to add the ability to set BearerTokens with environment variables instead of having to put them into the configuration file directly. This improves the security of FediBlockhole.

This PR differs slightly in that it uses pytest's `monkeypatch` instead of `patch` from `unittest.mock` to test the feature.

This PR also leaves the minimum version of Python as is, at 3.6.

Added some more verbose documentation in `README.md` on how to use the feature as well.

Fixes: #61