### PR TITLE
Adjust GitHub Actions workflows to pass zizmor checks in pedantic mode.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,22 @@ env:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-package:
     name: Build & verify package
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
         id: baipp
         with:
           skip-wheel: true
@@ -50,16 +55,16 @@ jobs:
 
     steps:
       - name: Download pre-built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
           path: dist
       - run: tar xf dist/*.tar.gz --strip-components=1
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - uses: hynek/setup-cached-uv@v2
+      - uses: hynek/setup-cached-uv@4300ec2180bc77d705e626a34e381b81a4772c51
       - run: uv venv
       - run: uv pip install .[dev]
       - run: |
@@ -67,7 +72,7 @@ jobs:
           uv run coverage run -p -m pytest
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-data-${{ matrix.python-version }}
           path: tests/.coverage.*
@@ -80,18 +85,18 @@ jobs:
 
     steps:
       - name: Download pre-built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
           path: dist
       - run: tar xf dist/*.tar.gz --strip-components=1
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: .python-version-default
-      - uses: hynek/setup-cached-uv@v2
+      - uses: hynek/setup-cached-uv@4300ec2180bc77d705e626a34e381b81a4772c51
 
       - name: Download coverage data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-data-*
           merge-multiple: true
@@ -111,7 +116,7 @@ jobs:
           uv run coverage report --fail-under=70
 
       - name: Upload HTML report if check failed.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: html-report
           path: htmlcov
@@ -123,27 +128,27 @@ jobs:
     needs: build-package
     steps:
       - name: Download pre-built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
           path: dist
       - run: tar xf dist/*.tar.gz --strip-components=1
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           # Keep in sync with tox/docs and .readthedocs.yaml.
           python-version: "3.12"
-      - uses: hynek/setup-cached-uv@v2
+      - uses: hynek/setup-cached-uv@4300ec2180bc77d705e626a34e381b81a4772c51
       - run: uv venv
 
   # pyright:
   #   name: Check types using pyright
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v5
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  #     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
   #       with:
   #         python-version-file: .python-version-default
-  #     - uses: hynek/setup-cached-uv@v2
+  #     - uses: hynek/setup-cached-uv@4300ec2180bc77d705e626a34e381b81a4772c51
 
   #     - run: uv venv
   #     - run: uv pip install .[dev] pyright typing
@@ -154,11 +159,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: .python-version-default
-      - uses: hynek/setup-cached-uv@v2
+      - uses: hynek/setup-cached-uv@4300ec2180bc77d705e626a34e381b81a4772c51
 
       - run: uv venv --python $(cat .python-version-default)
       - run: uv pip install -e .[dev]
@@ -171,6 +178,7 @@ jobs:
 
   # Ensure everything required is passing for branch protection.
   required-checks-pass:
+    name: Verify all required checks pass
     if: always()
 
     needs:
@@ -182,6 +190,6 @@ jobs:
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Ran the zizmor tool in pedantic mode to audit GitHub Actions, i.e.:

```
zizmor -p .
```

Adjusted GitHub Actions config in `ci.yml` to address the issues found by zizmor.

Fixes: #76 
