### PR TITLE
Reformatted files with Black formatter tool

### DIFF
--- a/tests/helpers/util.py
+++ b/tests/helpers/util.py
@@ -1,11 +1,10 @@
-""" Utility functions for tests
-"""
+"""Utility functions for tests"""
+
 from fediblockhole import setup_argparse, augment_args
 
 
 def shim_argparse(testargv: list = [], tomldata: str = None):
-    """Helper function to parse test args
-    """
+    """Helper function to parse test args"""
     ap = setup_argparse()
     args = ap.parse_args(testargv)
     if tomldata is not None:

--- a/tests/test_allowlist.py
+++ b/tests/test_allowlist.py
@@ -1,5 +1,4 @@
-""" Test allowlists
-"""
+"""Test allowlists"""
 
 import pytest
 from util import shim_argparse

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,5 +1,4 @@
-"""Test the commandline defined parameters correctly
-"""
+"""Test the commandline defined parameters correctly"""
 
 from fediblockhole import setup_argparse
 

--- a/tests/test_configfile.py
+++ b/tests/test_configfile.py
@@ -1,5 +1,4 @@
-"""Test the config file is loading parameters correctly
-"""
+"""Test the config file is loading parameters correctly"""
 
 from textwrap import dedent
 
@@ -95,16 +94,14 @@ merge_threshold = 35
 
 
 def test_destination_token_from_environment(monkeypatch):
-    tomldata = dedent(
-        """\
+    tomldata = dedent("""\
     blocklist_instance_destinations = [
       { domain='example.com', token='raw-token'},
       { domain='example2.com', token_env_var='TOKEN_ENV_VAR' },
       { domain='env-token.com' },
       { domain='www.env-token.com' },
     ]
-    """
-    )
+    """)
 
     monkeypatch.setenv("TOKEN_ENV_VAR", "env-token")
     monkeypatch.setenv("ENV-TOKEN_COM_TOKEN", "env-token")
@@ -119,16 +116,14 @@ def test_destination_token_from_environment(monkeypatch):
 
 
 def test_instance_sources_token_from_environment(monkeypatch):
-    tomldata = dedent(
-        """\
+    tomldata = dedent("""\
     blocklist_instance_sources = [
       { domain='example.com', token='raw-token'},
       { domain='example2.com', token_env_var='TOKEN_ENV_VAR' },
       { domain='env-token.com' },
       { domain='www.env-token.com' },
     ]
-    """
-    )
+    """)
 
     monkeypatch.setenv("TOKEN_ENV_VAR", "env-token")
     monkeypatch.setenv("ENV-TOKEN_COM_TOKEN", "env-token")

--- a/tests/test_domainblock.py
+++ b/tests/test_domainblock.py
@@ -1,5 +1,4 @@
-"""Test the DomainBlock structure
-"""
+"""Test the DomainBlock structure"""
 
 import pytest
 

--- a/tests/test_merge_comments.py
+++ b/tests/test_merge_comments.py
@@ -1,5 +1,4 @@
-""" Test merging of comments
-"""
+"""Test merging of comments"""
 
 from fediblockhole import merge_comments
 

--- a/tests/test_merge_thresholds.py
+++ b/tests/test_merge_thresholds.py
@@ -1,5 +1,4 @@
-"""Test merge with thresholds
-"""
+"""Test merge with thresholds"""
 
 from fediblockhole import merge_blocklists
 from fediblockhole.blocklists import Blocklist, parse_blocklist

--- a/tests/test_mergeplan.py
+++ b/tests/test_mergeplan.py
@@ -1,5 +1,4 @@
-"""Various mergeplan tests
-"""
+"""Various mergeplan tests"""
 
 from fediblockhole import apply_mergeplan, merge_blocklists, merge_comments
 from fediblockhole.blocklists import parse_blocklist

--- a/tests/test_parser_csv.py
+++ b/tests/test_parser_csv.py
@@ -1,5 +1,4 @@
-"""Tests of the CSV parsing
-"""
+"""Tests of the CSV parsing"""
 
 from fediblockhole.blocklists import BlocklistParserCSV
 from fediblockhole.const import SeverityLevel

--- a/tests/test_parser_csv_mastodon.py
+++ b/tests/test_parser_csv_mastodon.py
@@ -1,5 +1,4 @@
-"""Tests of the CSV parsing
-"""
+"""Tests of the CSV parsing"""
 
 from fediblockhole.blocklists import BlocklistParserMastodonCSV
 from fediblockhole.const import SeverityLevel

--- a/tests/test_parser_json.py
+++ b/tests/test_parser_json.py
@@ -1,5 +1,4 @@
-"""Tests of the CSV parsing
-"""
+"""Tests of the CSV parsing"""
 
 from fediblockhole.blocklists import BlocklistParserJSON
 from fediblockhole.const import SeverityLevel

--- a/tests/test_parser_rapidblockcsv.py
+++ b/tests/test_parser_rapidblockcsv.py
@@ -1,5 +1,4 @@
-"""Tests of the Rapidblock CSV parsing
-"""
+"""Tests of the Rapidblock CSV parsing"""
 
 from fediblockhole.blocklists import RapidBlockParserCSV
 from fediblockhole.const import SeverityLevel

--- a/tests/test_parser_rapidblockjson.py
+++ b/tests/test_parser_rapidblockjson.py
@@ -1,5 +1,4 @@
-"""Test parsing the RapidBlock JSON format
-"""
+"""Test parsing the RapidBlock JSON format"""
 
 from fediblockhole.blocklists import parse_blocklist
 from fediblockhole.const import SeverityLevel


### PR DESCRIPTION
Cleaned up the baseline formatting of the repo with Black.

It adjusted the leading docstring of the files, but left pretty much everything else unchanged.